### PR TITLE
new `noAuthPaths` option supporting wildcard characters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,6 +146,9 @@ type Proxy struct {
 	// Tips for performance: define your health check endpoint with a different length from the most frequently used endpoint, for example, use `/healthcheck` (len: 12) when `/most_used` (len: 10), instead of `/healthccc` (len: 10)
 	OriginHealthCheckPaths []string `yaml:"originHealthCheckPaths"`
 
+	// NoAuthPaths represents endpoints that requires NO authorization. Wildcard characters supported in Athenz policy are supported too.
+	NoAuthPaths []string `yaml:"noAuthPaths"`
+
 	// PreserveHost represents whether to preserve the host header from the request.
 	PreserveHost bool `yaml:"preserveHost"`
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -114,7 +114,7 @@ func TestNew(t *testing.T) {
 					NoAuthPaths: []string{
 						"/no-auth/any/*",
 						"/no-auth/single/a?c",
-						`/no-auth/no-regex/^$|([{`,
+						"/no-auth/no-regex/^$|([{",
 					},
 					PreserveHost: true,
 					Transport: Transport{

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,7 +111,12 @@ func TestNew(t *testing.T) {
 					Port:                   80,
 					BufferSize:             4096,
 					OriginHealthCheckPaths: []string{},
-					PreserveHost:           true,
+					NoAuthPaths: []string{
+						"/no-auth/any/*",
+						"/no-auth/single/a?c",
+						`/no-auth/no-regex/^$|([{`,
+					},
+					PreserveHost: true,
 					Transport: Transport{
 						TLSHandshakeTimeout:    10 * time.Second,
 						DisableKeepAlives:      false,

--- a/handler/error.go
+++ b/handler/error.go
@@ -48,4 +48,7 @@ const (
 
 	// ErrRoleTokenNotFound "role token not found"
 	ErrRoleTokenNotFound = "role token not found"
+
+	// ErrInvalidConfig "invalid proxy config".
+	ErrInvalidProxyConfig = "invalid proxy config"
 )

--- a/handler/error.go
+++ b/handler/error.go
@@ -49,6 +49,6 @@ const (
 	// ErrRoleTokenNotFound "role token not found"
 	ErrRoleTokenNotFound = "role token not found"
 
-	// ErrInvalidConfig "invalid proxy config".
+	// ErrInvalidProxyConfig "invalid proxy config".
 	ErrInvalidProxyConfig = "invalid proxy config"
 )

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kpango/glg"
 	"github.com/pkg/errors"
 
+	"github.com/AthenZ/athenz-authorizer/v5/policy"
 	"github.com/AthenZ/authorization-proxy/v4/config"
 	"github.com/AthenZ/authorization-proxy/v4/service"
 )
@@ -89,6 +90,17 @@ func New(cfg config.Proxy, bp httputil.BufferPool, prov service.Authorizationd) 
 			prov:         prov,
 			RoundTripper: transportFromCfg(cfg.Transport),
 			cfg:          cfg,
+			noAuthPaths: func(paths []string) []*policy.Assertion {
+				as := make([]*policy.Assertion, len(paths))
+				for i, p := range paths {
+					var err error
+					as[i], err = policy.NewAssertion("", ":"+p, "")
+					if err != nil {
+						glg.Fatalf("Invalid proxy.noAuthPaths: %s", p)
+					}
+				}
+				return as
+			}(cfg.NoAuthPaths),
 		},
 		ErrorHandler: handleError,
 	}

--- a/handler/transport_test.go
+++ b/handler/transport_test.go
@@ -548,7 +548,7 @@ func Test_transport_RoundTrip_WildcardBypass(t *testing.T) {
 			wantCloseCount: 0,
 		},
 		{
-			name: "NoAuthPaths '?' NOT match, bypass role token verification",
+			name: "NoAuthPaths '?' NOT match, verify role token",
 			fields: fields{
 				RoundTripper: nil,
 				prov: &service.AuthorizerdMock{
@@ -582,6 +582,37 @@ func Test_transport_RoundTrip_WildcardBypass(t *testing.T) {
 				},
 				{
 					r: wrapRequest("GET", "http://athenz.io/no-auth/123456", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+			},
+			wantErr:        true,
+			wantCloseCount: 1,
+		},
+		{
+			name: "NoAuthPaths empty string NOT match, verify role token",
+			fields: fields{
+				RoundTripper: nil,
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion(""),
+				},
+			},
+			argss: []args{
+				{
+					r: wrapRequest("GET", "http://athenz.io", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/", nil),
 					body: &readCloseCounter{
 						ReadErr: errors.New("readCloseCounter.Read not implemented"),
 					},

--- a/handler/transport_test.go
+++ b/handler/transport_test.go
@@ -2,11 +2,13 @@ package handler
 
 import (
 	"errors"
+	"io"
 	"net/http"
 	"reflect"
 	"testing"
 
 	authorizerd "github.com/AthenZ/athenz-authorizer/v5"
+	"github.com/AthenZ/athenz-authorizer/v5/policy"
 	"github.com/AthenZ/authorization-proxy/v4/config"
 	"github.com/AthenZ/authorization-proxy/v4/service"
 )
@@ -26,10 +28,18 @@ func (r *readCloseCounter) Close() error {
 }
 
 func Test_transport_RoundTrip(t *testing.T) {
+	wrapAssertion := func(s string) *policy.Assertion {
+		a, err := policy.NewAssertion("", ":"+s, "")
+		if err != nil {
+			panic(err)
+		}
+		return a
+	}
 	type fields struct {
 		RoundTripper http.RoundTripper
 		prov         service.Authorizationd
 		cfg          config.Proxy
+		noAuthPaths  []*policy.Assertion
 	}
 	type args struct {
 		r    *http.Request
@@ -287,6 +297,90 @@ func Test_transport_RoundTrip(t *testing.T) {
 			wantErr:        true,
 			wantCloseCount: 1,
 		},
+		{
+			name: "NoAuthPaths match, bypass role token verification",
+			fields: fields{
+				RoundTripper: &RoundTripperMock{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: 200,
+						}, nil
+					},
+				},
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth"),
+				},
+			},
+			args: args{
+				r: func() *http.Request {
+					r, _ := http.NewRequest("GET", "http://athenz.io/no-auth", nil)
+					return r
+				}(),
+				body: &readCloseCounter{
+					ReadErr: errors.New("readCloseCounter.Read not implemented"),
+				},
+			},
+			want: &http.Response{
+				StatusCode: 200,
+			},
+			wantErr:        false,
+			wantCloseCount: 0,
+		},
+		{
+			name: "NoAuthPaths NONE match, verify role token",
+			fields: fields{
+				RoundTripper: nil,
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth"),
+				},
+			},
+			args: args{
+				r: func() *http.Request {
+					r, _ := http.NewRequest("GET", "http://athenz.io/no-auth/", nil)
+					return r
+				}(),
+				body: &readCloseCounter{
+					ReadErr: errors.New("readCloseCounter.Read not implemented"),
+				},
+			},
+			wantErr:        true,
+			wantCloseCount: 1,
+		},
+		{
+			name: "NoAuthPaths NOT set, verify role token",
+			fields: fields{
+				RoundTripper: nil,
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+			},
+			args: args{
+				r: func() *http.Request {
+					r, _ := http.NewRequest("GET", "http://athenz.io/no-auth", nil)
+					return r
+				}(),
+				body: &readCloseCounter{
+					ReadErr: errors.New("readCloseCounter.Read not implemented"),
+				},
+			},
+			wantErr:        true,
+			wantCloseCount: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -294,6 +388,7 @@ func Test_transport_RoundTrip(t *testing.T) {
 				RoundTripper: tt.fields.RoundTripper,
 				prov:         tt.fields.prov,
 				cfg:          tt.fields.cfg,
+				noAuthPaths:  tt.fields.noAuthPaths,
 			}
 			if tt.args.body != nil {
 				tt.args.r.Body = tt.args.body
@@ -309,6 +404,263 @@ func Test_transport_RoundTrip(t *testing.T) {
 			if tt.args.body != nil {
 				if tt.args.body.CloseCount != tt.wantCloseCount {
 					t.Errorf("Body was closed %d times, expected %d", tt.args.body.CloseCount, tt.wantCloseCount)
+				}
+			}
+		})
+	}
+}
+
+func Test_transport_RoundTrip_WildcardBypass(t *testing.T) {
+	wrapAssertion := func(s string) *policy.Assertion {
+		a, err := policy.NewAssertion("", ":"+s, "")
+		if err != nil {
+			panic(err)
+		}
+		return a
+	}
+	wrapRequest := func(method, url string, body io.Reader) *http.Request {
+		r, err := http.NewRequest(method, url, body)
+		if err != nil {
+			panic(err)
+		}
+		return r
+	}
+	type fields struct {
+		RoundTripper http.RoundTripper
+		prov         service.Authorizationd
+		cfg          config.Proxy
+		noAuthPaths  []*policy.Assertion
+	}
+	type args struct {
+		r    *http.Request
+		body *readCloseCounter
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		argss          []args
+		want           *http.Response
+		wantErr        bool
+		wantCloseCount int
+	}{
+		{
+			name: "NoAuthPaths '*' match, bypass role token verification",
+			fields: fields{
+				RoundTripper: &RoundTripperMock{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: 200,
+						}, nil
+					},
+				},
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth*"),
+				},
+			},
+			argss: []args{
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-authhhhhh", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/abc", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/abc/483", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+			},
+			want: &http.Response{
+				StatusCode: 200,
+			},
+			wantErr:        false,
+			wantCloseCount: 0,
+		},
+		{
+			name: "NoAuthPaths '?' match, bypass role token verification",
+			fields: fields{
+				RoundTripper: &RoundTripperMock{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: 200,
+						}, nil
+					},
+				},
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth/a??c"),
+				},
+			},
+			argss: []args{
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/aaac", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/accc", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/abbc", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+			},
+			want: &http.Response{
+				StatusCode: 200,
+			},
+			wantErr:        false,
+			wantCloseCount: 0,
+		},
+		{
+			name: "NoAuthPaths '?' NOT match, bypass role token verification",
+			fields: fields{
+				RoundTripper: nil,
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth/a??c"),
+				},
+			},
+			argss: []args{
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/aaaa", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/cccc", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/abbbc", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/123456", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+			},
+			wantErr:        true,
+			wantCloseCount: 1,
+		},
+		{
+			name: "NoAuthPaths NO escape, verify role token",
+			fields: fields{
+				RoundTripper: &RoundTripperMock{
+					RoundTripFunc: func(req *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: 200,
+						}, nil
+					},
+				},
+				prov: &service.AuthorizerdMock{
+					VerifyFunc: func(r *http.Request, act, res string) (authorizerd.Principal, error) {
+						return nil, errors.New("role token error")
+					},
+				},
+				cfg: config.Proxy{},
+				noAuthPaths: []*policy.Assertion{
+					wrapAssertion("/no-auth/wildcard/\\*"),
+					wrapAssertion("/no-auth/single/\\?"),
+					wrapAssertion("/no-auth/escape/\\\\"),
+				},
+			},
+			argss: []args{
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/wildcard/*", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/single/?", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+				{
+					r: wrapRequest("GET", "http://athenz.io/no-auth/escape/\\", nil),
+					body: &readCloseCounter{
+						ReadErr: errors.New("readCloseCounter.Read not implemented"),
+					},
+				},
+			},
+			wantErr:        true,
+			wantCloseCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &transport{
+				RoundTripper: tt.fields.RoundTripper,
+				prov:         tt.fields.prov,
+				cfg:          tt.fields.cfg,
+				noAuthPaths:  tt.fields.noAuthPaths,
+			}
+			for _, args := range tt.argss {
+				if args.body != nil {
+					args.r.Body = args.body
+				}
+				got, err := tr.RoundTrip(args.r)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("transport.RoundTrip() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("transport.RoundTrip() = %v, want %v", got, tt.want)
+				}
+				if args.body != nil {
+					if args.body.CloseCount != tt.wantCloseCount {
+						t.Errorf("Body was closed %d times, expected %d", args.body.CloseCount, tt.wantCloseCount)
+					}
 				}
 			}
 		})

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -29,6 +29,10 @@ proxy:
   port: 80
   bufferSize: 4096
   originHealthCheckPaths: []
+  noAuthPaths:
+    - "/no-auth/any/*"
+    - "/no-auth/single/a?c"
+    - "/no-auth/no-regex/^$|([{"
   preserveHost: true
   transport:
     tlsHandshakeTimeout: "10s"


### PR DESCRIPTION
# Description

```yaml
proxy: 
  scheme: http
  originHealthCheckPaths: # exact match
    - "/status.html"
  noAuthPaths: # support wildcard '*' and '?'
    - "/no-auth/any/*"
    - "/no-auth/single/a?c"
    - "/no-auth/no-regex/^$|([{"
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer
- [x] Use `Squash and merge`
- [x] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [x] Delete the branch after merge
