### PR TITLE
[minor] Add insecure ciphersuites option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,9 @@ type TLS struct {
 
 	// DisableCipherSuites represents list of disable ciphersuites
 	DisableCipherSuites []string `yaml:"disableCipherSuites"`
+
+	// EnableInsecureCipherSuites represents list of enable insecureCipherSuites
+	EnableInsecureCipherSuites []string `yaml:"enableInsecureCipherSuites"`
 }
 
 // HealthCheck represents the health check server configuration.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -97,6 +97,10 @@ func TestNew(t *testing.T) {
 							"TLS_RSA_WITH_AES_128_CBC_SHA",
 							"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 						},
+						EnableInsecureCipherSuites: []string{
+							"TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+							"TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+						},
 					},
 					HealthCheck: HealthCheck{
 						Port:     6082,

--- a/service/tls.go
+++ b/service/tls.go
@@ -73,7 +73,7 @@ func NewTLSConfigWithTLSCertificateCache(cfg config.TLS) (*tls.Config, *TLSCerti
 
 	cs, err := cipherSuites(cfg.DisableCipherSuites, cfg.EnableInsecureCipherSuites)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "cipherSuite(cfg.DisableCipherSuites)")
+		return nil, nil, errors.Wrap(err, "cipherSuite(cfg.DisableCipherSuites, cfg.EnableInsecureCipherSuites)")
 	}
 
 	t := &tls.Config{

--- a/service/tls.go
+++ b/service/tls.go
@@ -251,11 +251,6 @@ func isValidDuration(durationString string) (bool, error) {
 
 // cipherSuites returns list of available cipher suites
 func cipherSuites(dcs []string, eics []string) ([]uint16, error) {
-	var (
-		availableCipherSuites     []uint16
-		availableCipherSuitesName []string
-	)
-
 	ciphers := make(map[string]uint16)
 	for _, c := range tls.CipherSuites() {
 		ciphers[c.Name] = c.ID
@@ -263,7 +258,7 @@ func cipherSuites(dcs []string, eics []string) ([]uint16, error) {
 	if len(dcs) != 0 {
 		for _, cipher := range dcs {
 			if _, ok := ciphers[cipher]; !ok {
-				err := glg.Errorf("Invalid cipher suite: %s", cipher)
+				err := errors.WithMessage(errors.New(cipher), "Invalid cipher suite")
 				return nil, err
 			}
 			delete(ciphers, cipher)
@@ -276,12 +271,16 @@ func cipherSuites(dcs []string, eics []string) ([]uint16, error) {
 		}
 		for _, cipher := range eics {
 			if _, ok := insecureCiphers[cipher]; !ok {
-				err := glg.Errorf("Invalid insecure cipher suite: %s", cipher)
+				err := errors.WithMessage(errors.New(cipher), "Invalid insecure cipher suite")
 				return nil, err
 			}
 			ciphers[cipher] = insecureCiphers[cipher]
 		}
 	}
+
+	availableCipherSuites := make([]uint16, 0, len(ciphers))
+	availableCipherSuitesName := make([]string, 0, len(ciphers))
+
 	for cipherName, cipherId := range ciphers {
 		availableCipherSuites = append(availableCipherSuites, cipherId)
 		availableCipherSuitesName = append(availableCipherSuitesName, cipherName)

--- a/service/tls_test.go
+++ b/service/tls_test.go
@@ -18,7 +18,6 @@ import (
 	"time"
 
 	"github.com/AthenZ/authorization-proxy/v4/config"
-	"github.com/kpango/glg"
 )
 
 func TestNewTLSConfig(t *testing.T) {
@@ -1404,7 +1403,7 @@ func Test_cipherSuites(t *testing.T) {
 				eics: nil,
 			},
 			want:    nil,
-			wantErr: glg.Errorf("Invalid cipher suite: dummy"),
+			wantErr: errors.New("Invalid cipher suite: dummy"),
 		},
 		{
 			name: "Check disable cipher suites containing SHA-1",
@@ -1476,7 +1475,20 @@ func Test_cipherSuites(t *testing.T) {
 				},
 			},
 			want:    nil,
-			wantErr: glg.Errorf("Invalid insecure cipher suite: insecureDummy"),
+			wantErr: errors.New("Invalid insecure cipher suite: insecureDummy"),
+		},
+		{
+			name: "Check the same cipher suite is specified for disableCipherSuites and enableInsecureCipherSuites",
+			args: args{
+				dcs: []string{
+					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+				},
+				eics: []string{
+					"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
+				},
+			},
+			want:    nil,
+			wantErr: errors.New("Invalid insecure cipher suite: TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA"),
 		},
 	}
 	for _, tt := range tests {

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -18,6 +18,9 @@ server:
       - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
       - TLS_RSA_WITH_AES_128_CBC_SHA
       - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+    enableInsecureCipherSuites:
+      - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+      - TLS_RSA_WITH_3DES_EDE_CBC_SHA
   healthCheck:
     port: 6082
     endpoint: /healthz


### PR DESCRIPTION
# Description

- Change default ciphersuites
- Add insecure ciphersuites option

```bash
server:
  tls:
    enableInsecureCipherSuites:
      - TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
      - TLS_RSA_WITH_3DES_EDE_CBC_SHA
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer
- [ ] Use `Squash and merge`
- [ ] Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- [ ] Delete the branch after merge
