### PR TITLE
Add KeepAlive settings between client and proxy 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,9 @@ type Server struct {
 	// ShutdownDelay represents the delay duration between the health check server shutdown and the api server shutdown.
 	ShutdownDelay string `yaml:"shutdownDelay"`
 
+	// DisableKeepAlives requests whether HTTP keep-alives are disabled for the server.
+	DisableKeepAlives bool `yaml:"disableKeepAlives"`
+
 	// TLS represents the TLS configuration of the authorization proxy.
 	TLS TLS `yaml:"tls"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type Server struct {
 	// ShutdownDelay represents the delay duration between the health check server shutdown and the api server shutdown.
 	ShutdownDelay string `yaml:"shutdownDelay"`
 
-	// DisableKeepAlives requests whether HTTP keep-alives are disabled for the server.
+	// DisableKeepAlives represents whether HTTP keep-alive connections should be disabled.
 	DisableKeepAlives bool `yaml:"disableKeepAlives"`
 
 	// TLS represents the TLS configuration of the authorization proxy.

--- a/config/config.go
+++ b/config/config.go
@@ -64,7 +64,7 @@ type Server struct {
 	// ShutdownDelay represents the delay duration between the health check server shutdown and the api server shutdown.
 	ShutdownDelay string `yaml:"shutdownDelay"`
 
-	// DisableKeepAlives represents whether HTTP keep-alive connections should be disabled.
+	// DisableKeepAlives represents whether HTTP keep-alive connections should be disabled between the client and the Provider Sidecar.
 	DisableKeepAlives bool `yaml:"disableKeepAlives"`
 
 	// TLS represents the TLS configuration of the authorization proxy.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -81,7 +81,7 @@ func TestNew(t *testing.T) {
 					Timeout:           "10s",
 					ShutdownTimeout:   "10s",
 					ShutdownDelay:     "9s",
-					DisableKeepAlives: false,
+					DisableKeepAlives: true,
 					TLS: TLS{
 						Enable:            true,
 						CertPath:          "test/data/dummyServer.crt",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -77,10 +77,11 @@ func TestNew(t *testing.T) {
 			want: &Config{
 				Version: "v2.0.0",
 				Server: Server{
-					Port:            8082,
-					Timeout:         "10s",
-					ShutdownTimeout: "10s",
-					ShutdownDelay:   "9s",
+					Port:              8082,
+					Timeout:           "10s",
+					ShutdownTimeout:   "10s",
+					ShutdownDelay:     "9s",
+					DisableKeepAlives: false,
 					TLS: TLS{
 						Enable:            true,
 						CertPath:          "test/data/dummyServer.crt",

--- a/service/server.go
+++ b/service/server.go
@@ -126,7 +126,7 @@ func NewServer(opts ...Option) (Server, error) {
 			Addr:    fmt.Sprintf(":%d", s.cfg.Port),
 			Handler: s.srvHandler,
 		}
-		s.srv.SetKeepAlivesEnabled(true)
+		s.srv.SetKeepAlivesEnabled(!s.cfg.DisableKeepAlives)
 		if s.cfg.TLS.Enable {
 			s.srv.TLSConfig = s.tlsConfig
 		}

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -5,7 +5,7 @@ server:
   timeout: 10s
   shutdownTimeout: 10s
   shutdownDelay: 9s
-  disableKeepAlives: false
+  disableKeepAlives: true
   tls:
     enable: true
     certPath: "test/data/dummyServer.crt"

--- a/test/data/example_config.yaml
+++ b/test/data/example_config.yaml
@@ -5,6 +5,7 @@ server:
   timeout: 10s
   shutdownTimeout: 10s
   shutdownDelay: 9s
+  disableKeepAlives: false
   tls:
     enable: true
     certPath: "test/data/dummyServer.crt"


### PR DESCRIPTION
# Description
- add KeepAlive Settings
    - Add a configuration setting to enable/disable KeepAlive between the client and authorization-proxy.

- config.yaml
```
version: v2.0.0
server:
  disableKeepAlives: false
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [ ] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [ ] Tested and linted the code
- [ ] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
