### PR TITLE
Add warning log if rsa key

### DIFF
--- a/service/tls.go
+++ b/service/tls.go
@@ -304,6 +304,6 @@ func defaultCipherSuitesMap() map[string]uint16 {
 // warnIfRSAPrivateKey output warning log if the private key is RSA.
 func warnIfRSAPrivateKey(privateKey crypto.PrivateKey) {
 	if _, ok := privateKey.(*rsa.PrivateKey); ok {
-		glg.Warn("The private key is RSA. Consider using an ECDSA key for better performance.")
+		glg.Warn("The private key used in the server certificate is RSA. Consider using an ECDSA key for better performance.")
 	}
 }


### PR DESCRIPTION
# Description

- Add warning log if rsa key

## Example

config.yaml

```bash
server:
  tls:
    certRefreshPeriod: "30s"
```

```bash
// start by specifying server certificate with RSA key.
2024-09-09 06:42:30     [INFO]: initAuthorizers: added access token authorizer having param: {enable:true verifyCertThumbprint:false certBackdateDur:0h certOffsetDur:0h verifyClientID:false authorizedClientIDs:map[]}
2024-09-09 06:42:30     [INFO]: initAuthorizers: added role token authorizer
2024-09-09 06:42:30     [INFO]: available cipher suites: TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256:TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
2024-09-09 06:42:30     [WARN]: The private key is RSA. Consider using an ECDSA key for better performance.
2024-09-09 06:42:30     [INFO]: Fetching JWK Set
2024-09-09 06:42:30     [INFO]: Updating athenz pubkey
2024-09-09 06:42:30     [INFO]: Updating ZMS athenz pubkey
2024-09-09 06:42:30     [INFO]: Fetching public key entries
2024-09-09 06:42:30     [INFO]: Updating ZTS athenz pubkey
2024-09-09 06:42:30     [INFO]: Fetching public key entries
2024-09-09 06:42:31     [INFO]: Fetch public key entries success
2024-09-09 06:42:31     [INFO]: Update ZMS athenz pubkey success
2024-09-09 06:42:31     [INFO]: Fetch public key entries success
2024-09-09 06:42:31     [INFO]: Update ZTS athenz pubkey success
2024-09-09 06:42:31     [INFO]: [1725864151] will update policy
2024-09-09 06:42:31     [INFO]: will fetch policy for domain: yby.taniwa.provider.example
2024-09-09 06:42:32     [INFO]: [1725864151] update policy done
2024-09-09 06:42:32     [INFO]: Fetch JWK Set success
2024-09-09 06:42:32     [INFO]: Starting pubkey updater
2024-09-09 06:42:32     [INFO]: Starting policyd updater
2024-09-09 06:42:32     [INFO]: Starting jwk updater
2024-09-09 06:42:32     [INFO]: authorization proxy api server starting

2024-09-09 06:43:02     [INFO]: Start refreshing server certificate
2024-09-09 06:43:02     [INFO]: Server certificate is same as the file

// server certificate was switched to an EC key.
2024-09-09 06:43:32     [INFO]: Start refreshing server certificate
2024-09-09 06:43:32     [INFO]: Refreshed server certificate

// server certificate was switched back to an RSA key.
2024-09-09 06:44:02     [INFO]: Start refreshing server certificate
2024-09-09 06:44:02     [WARN]: The private key is RSA. Consider using an ECDSA key for better performance.
2024-09-09 06:44:02     [INFO]: Refreshed server certificate
```

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [x] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [x] Made corresponding changes to the documentation
- [x] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
