### PR TITLE
Introduce the simpleBuffer as implementation of the httputil.BufferPool.

### DIFF
--- a/infra/simple_buffer.go
+++ b/infra/simple_buffer.go
@@ -1,0 +1,56 @@
+// Copyright 2024 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infra
+
+import (
+	"net/http/httputil"
+	"sync"
+	"sync/atomic"
+)
+
+type simpleBuffer struct {
+	pool sync.Pool
+	size *uint64
+}
+
+// NewSimpleBuffer implements httputil.BufferPool for providing byte slices of same size.
+func NewSimpleBuffer(size uint64) httputil.BufferPool {
+	if size == 0 {
+		return nil
+	}
+
+	b := &simpleBuffer{
+		size: &size,
+	}
+
+	b.pool = sync.Pool{
+		New: func() interface{} {
+			return make([]byte, atomic.LoadUint64(b.size))
+		},
+	}
+
+	return b
+}
+
+// Get returns a slice from the pool, and remove it from the pool. New slice may be created when needed.
+func (b *simpleBuffer) Get() []byte {
+	return b.pool.Get().([]byte)
+}
+
+// Put adds the given slice back to internal pool.
+func (b *simpleBuffer) Put(buf []byte) {
+	bufCap := cap(buf)
+	b.pool.Put(buf[0:bufCap])
+}

--- a/infra/simple_buffer_test.go
+++ b/infra/simple_buffer_test.go
@@ -1,0 +1,280 @@
+// Copyright 2024 LY Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infra
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestNewSimpleBuffer(t *testing.T) {
+	type args struct {
+		size uint64
+	}
+	type testcase struct {
+		name      string
+		args      args
+		want      *simpleBuffer
+		checkFunc func(got, want *simpleBuffer) error
+	}
+	tests := []testcase{
+		{
+			name: "Check newBuffer, with 0 size",
+			args: args{
+				size: 0,
+			},
+			want: nil,
+			checkFunc: func(got, want *simpleBuffer) error {
+				if !reflect.DeepEqual(got, want) {
+					return &NotEqualError{"", got, want}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Check newBuffer, positive size",
+			args: args{
+				size: 37,
+			},
+			want: &simpleBuffer{
+				size: func(i uint64) *uint64 { return &i }(37),
+			},
+			checkFunc: func(got, want *simpleBuffer) error {
+				if *(got.size) != *(want.size) {
+					return &NotEqualError{"size", *(got.size), *(want.size)}
+				}
+
+				buffer := got.Get()
+				if uint64(cap(buffer)) != *(want.size) {
+					return &NotEqualError{"pool", cap(buffer), *(want.size)}
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NewSimpleBuffer(tt.args.size)
+
+			if got == nil && tt.want == nil {
+				// skip on both nil
+				return
+			}
+			if err := tt.checkFunc(got.(*simpleBuffer), tt.want); err != nil {
+				t.Errorf("newBuffer() %v", err)
+				return
+			}
+		})
+	}
+}
+
+func TestSimpleBufferGet(t *testing.T) {
+	type fields struct {
+		pool sync.Pool
+		size *uint64
+	}
+	type testcase struct {
+		name   string
+		fields fields
+		want   []byte
+	}
+	tests := []testcase{
+		{
+			name: "Check simpleBuffer Get, get from internal pool",
+			fields: fields{
+				pool: sync.Pool{
+					New: func() interface{} {
+						return []byte("pool-new-91")
+					},
+				},
+			},
+			want: []byte("pool-new-91"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &simpleBuffer{
+				pool: tt.fields.pool,
+				size: tt.fields.size,
+			}
+
+			got := b.Get()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("simpleBuffer.Get() %v", &NotEqualError{"", got, tt.want})
+				return
+			}
+		})
+	}
+}
+
+func TestSimpleBufferPut(t *testing.T) {
+	type fields struct {
+		pool sync.Pool
+		size *uint64
+	}
+	type args struct {
+		buf []byte
+	}
+	type testcase struct {
+		name      string
+		fields    fields
+		args      args
+		checkFunc func(got *simpleBuffer) error
+	}
+	tests := []testcase{
+		{
+			name: "Check simpleBuffer Put, with 0 size",
+			fields: fields{
+				pool: sync.Pool{New: func() interface{} { return make([]byte, 128) }},
+				size: func(i uint64) *uint64 { return &i }(128),
+			},
+			args: args{
+				buf: make([]byte, 0),
+			},
+			checkFunc: func(got *simpleBuffer) error {
+				wantSize := uint64(128)
+				wantBufLen := 0
+				wantBufCap := 0
+
+				gotSize := *(got.size)
+				if gotSize != wantSize {
+					return &NotEqualError{"size", gotSize, wantSize}
+				}
+
+				gotBuffer := got.Get()
+				gotBufLen := len(gotBuffer)
+				if gotBufLen != wantBufLen {
+					return &NotEqualError{"buffer len", gotBufLen, wantBufLen}
+				}
+				gotBufCap := cap(gotBuffer)
+				if gotBufCap != wantBufCap {
+					return &NotEqualError{"buffer cap", gotBufCap, wantBufCap}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Check simpleBuffer Put, with buffer len and cap > current size",
+			fields: fields{
+				pool: sync.Pool{New: func() interface{} { return make([]byte, 128) }},
+				size: func(i uint64) *uint64 { return &i }(128),
+			},
+			args: args{
+				buf: make([]byte, 129),
+			},
+			checkFunc: func(got *simpleBuffer) error {
+				wantSize := uint64(128)
+				wantBufLen := 129
+				wantBufCap := 129
+
+				gotSize := *(got.size)
+				if gotSize != wantSize {
+					return &NotEqualError{"size", gotSize, wantSize}
+				}
+
+				gotBuffer := got.Get()
+				gotBufLen := len(gotBuffer)
+				if gotBufLen != wantBufLen {
+					return &NotEqualError{"len(buffer)", gotBufLen, wantBufLen}
+				}
+				gotBufCap := cap(gotBuffer)
+				if gotBufCap != wantBufCap {
+					return &NotEqualError{"cap(buffer)", gotBufCap, wantBufCap}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Check simpleBuffer Put, with buffer len and cap == current size",
+			fields: fields{
+				pool: sync.Pool{New: func() interface{} { return make([]byte, 128) }},
+				size: func(i uint64) *uint64 { return &i }(128),
+			},
+			args: args{
+				buf: make([]byte, 128),
+			},
+			checkFunc: func(got *simpleBuffer) error {
+				wantSize := uint64(128)
+				wantBufLen := 128
+				wantBufCap := 128
+
+				gotSize := *(got.size)
+				if gotSize != wantSize {
+					return &NotEqualError{"size", gotSize, wantSize}
+				}
+
+				gotBuffer := got.Get()
+				gotBufLen := len(gotBuffer)
+				if gotBufLen != wantBufLen {
+					return &NotEqualError{"len(buffer)", gotBufLen, wantBufLen}
+				}
+				gotBufCap := cap(gotBuffer)
+				if gotBufCap != wantBufCap {
+					return &NotEqualError{"cap(buffer)", gotBufCap, wantBufCap}
+				}
+				return nil
+			},
+		},
+		{
+			name: "Check simpleBuffer Put, with buffer len > cap",
+			fields: fields{
+				pool: sync.Pool{New: func() interface{} { return make([]byte, 128) }},
+				size: func(i uint64) *uint64 { return &i }(128),
+			},
+			args: args{
+				buf: make([]byte, 129, 256),
+			},
+			checkFunc: func(got *simpleBuffer) error {
+				wantSize := uint64(128)
+				wantBufLen := 256
+				wantBufCap := 256
+
+				gotSize := *(got.size)
+				if gotSize != wantSize {
+					return &NotEqualError{"size", gotSize, wantSize}
+				}
+
+				gotBuffer := got.Get()
+				gotBufLen := len(gotBuffer)
+				if gotBufLen != wantBufLen {
+					return &NotEqualError{"len(buffer)", gotBufLen, wantBufLen}
+				}
+				gotBufCap := cap(gotBuffer)
+				if gotBufCap != wantBufCap {
+					return &NotEqualError{"cap(buffer)", gotBufCap, wantBufCap}
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &simpleBuffer{
+				pool: tt.fields.pool,
+				size: tt.fields.size,
+			}
+			b.Put(tt.args.buf)
+			if err := tt.checkFunc(b); err != nil {
+				t.Errorf("buffer.Put() %v", err)
+				return
+			}
+		})
+	}
+}

--- a/usecase/authz_proxyd.go
+++ b/usecase/authz_proxyd.go
@@ -73,7 +73,7 @@ func New(cfg config.Config) (AuthzProxyDaemon, error) {
 
 	serverOption := []service.Option{
 		service.WithServerConfig(cfg.Server),
-		service.WithRestHandler(handler.New(cfg.Proxy, infra.NewBuffer(cfg.Proxy.BufferSize), athenz, metrics)),
+		service.WithRestHandler(handler.New(cfg.Proxy, infra.NewSimpleBuffer(cfg.Proxy.BufferSize), athenz, metrics)),
 		service.WithDebugHandler(debugMux),
 		service.WithGRPCHandler(gh),
 		service.WithGRPCCloser(closer),


### PR DESCRIPTION
# Description

There are some bugs in the buffer pool implementation of the infra package.

1. Unnecessary clean slice.

https://github.com/AthenZ/authorization-proxy/blob/4bc56bbbf670d016cd84167662c26a674a959953/infra/buffer.go#L74

The copyBuffer function in the httputil.ReverseProxy package checks the length of the slice that given as argument(buf), and if the length of the slice is 0, it makes a slice as 32 * 1024 (32KB). 
https://github.com/golang/go/blob/69234ded30614a471c35cef5d87b0e0d3c136cd9/src/net/http/httputil/reverseproxy.go#L642
The authorisation-proxy (infra package) always reset the slice length to 0 before put it to the pool, this means that the buffer size is always 32KB when copying.


2. Incorrect comparison conditions.

https://github.com/AthenZ/authorization-proxy/blob/4bc56bbbf670d016cd84167662c26a674a959953/infra/buffer.go#L64

Even if a slice with the same capacity as buffer.size is put, a new slice will be created.
Since httputil.ReverseProxy does not change the slice size, results in memory allocation every time a response is copied.
The impact of this issue is limited, you probably can't notice it if you don't specify a large value for bufferSize (see result of memory usage).


In this PR, a new simpleBuffer is introduced to solve the above problem. 
The current implementation of BufferPool is overkill because the httputil.Reverseproxy does not resize the slice used to copy the response. 
However the current implementation is still exists, it could be used for other purposes.

e.g. memory usage (origin server returns small response)

before

| bufferSize | requests/sec | duration |max rss (kb) |
|:-----------|:-------------|:---------|:-------------|
| 419430400 | 1/s | 1s | 440288 |
| 419430400 | 1/s | 10s | 1669664 |
| 419430400 | 100/s | 1s | 18902020 |
| 419430400 | 100/s | 10s | 27421440 |

after

| bufferSize | requests/sec | duration | max rss (kb) |
|:-----------|:-------------|:---------|:-------------|
| 419430400 | 1/s | 1s | 435296 |
| 419430400 | 1/s | 10s | 441516 |
| 419430400 | 100/s | 1s | 3351424 |
| 419430400 | 100/s | 10s | 6216764 |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Non-code changes (update documentation, pipeline, etc.)

### Flags

- [ ] Breaks backward compatibility
- [ ] Requires a documentation update
- [ ] Has untestable code

## Related issue/PR

**Delete this section if there are no issues or pull requests that relate to this pull request.**
- Fixes #_issue_
- Closes #_PR_

---

## Checklist

- [x] Followed the guidelines in the CONTRIBUTING document
- [ ] Added prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]` in the PR title if necessary
- [x] Tested and linted the code
- [x] Commented the code
- [ ] Made corresponding changes to the documentation
- [ ] Passed all pipeline checking

## Checklist for maintainer

- Use `Squash and merge`
- Double-confirm the merge message has prefix `[skip ci]`/`[ci skip]`/`[no ci]`/`[skip actions]`/`[actions skip]`
- Delete the branch after merge
